### PR TITLE
Development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+## Cursor Cloud specific instructions
+
+This is a Python CLI tool (single script `graham.py`) that scrapes Paul Graham's essays and builds an EPUB ebook. There is no web server, no database, and no test suite.
+
+### System dependencies
+
+- **Python 3** (pre-installed)
+- **uv** (`~/.local/bin/uv`) — Python package manager; installed via `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- **pandoc** (`apt install pandoc`) — converts Markdown to EPUB
+- **GNU Make** (pre-installed)
+
+Ensure `$HOME/.local/bin` is on `PATH` for `uv` to work.
+
+### Running the pipeline
+
+See `Makefile` for all targets. The full build is:
+
+```
+make venv    # create .venv and install Python deps
+make fetch   # download 230+ essays (~25s with network)
+make merge   # combine into graham.md
+make epub    # build graham.epub (requires cover.png in repo root)
+```
+
+Or simply `make all` (which also runs `dependencies` and `wordcount`).
+
+### Gotchas
+
+- `make fetch` requires internet access to paulgraham.com. It takes ~25 seconds and writes 230 markdown files to `essays/`.
+- `make epub` produces pandoc warnings about duplicate footnote references; this is expected and does not affect the output.
+- The `cover.png` file must exist for the EPUB cover image. It is tracked in the repo.
+- `make pdf` requires `calibre` (`ebook-convert`), which is optional and not needed for the standard pipeline.
+- There are no automated tests. Correctness is verified by running the pipeline end-to-end and checking that `graham.epub`, `graham.md`, and `essays.csv` are generated.
+- The `dependencies` Makefile target uses `sudo apt` on Linux, which may prompt for a password; install pandoc and uv manually if needed.

--- a/graham.py
+++ b/graham.py
@@ -50,7 +50,7 @@ def parse_main_page(base_url: str, articles_url: str):
 toc = list(reversed(parse_main_page("https://paulgraham.com/", "articles.html")))
 
 
-def convert_to_pandoc_footnotes(text):
+def convert_to_pandoc_footnotes(text, essay_id=""):
     if isinstance(text, bytes):
         text = text.decode("utf-8")
 
@@ -79,14 +79,15 @@ def convert_to_pandoc_footnotes(text):
 
     text = re.sub(notes_section_pattern, "", text, flags=re.DOTALL | re.IGNORECASE)
 
+    prefix = f"{essay_id}-" if essay_id else ""
     for note_num in footnote_definitions.keys():
-        text = re.sub(rf"\[{note_num}\]", f"[^{note_num}]", text)
+        text = re.sub(rf"\[{note_num}\]", f"[^{prefix}{note_num}]", text)
 
     if footnote_definitions:
         footnote_defs = []
         for note_num in sorted(footnote_definitions.keys(), key=int):
             footnote_content = footnote_definitions[note_num]
-            footnote_defs.append(f"[^{note_num}]: {footnote_content}")
+            footnote_defs.append(f"[^{prefix}{note_num}]: {footnote_content}")
 
         text += "\n\n" + "\n\n".join(footnote_defs)
 
@@ -147,7 +148,7 @@ for entry in toc:
             ]
 
             encoded = " ".join(parsed).encode()
-            processed_content = convert_to_pandoc_footnotes(encoded)
+            processed_content = convert_to_pandoc_footnotes(encoded, str(ART_NO).zfill(3))
             file.write(processed_content)
 
             print(f"✅ {str(ART_NO).zfill(3)} {TITLE}")


### PR DESCRIPTION
Prefix footnote IDs with essay number to fix EPUB footnote content collision.

When compiling multiple markdown files into an EPUB, pandoc would see duplicate footnote IDs (e.g., `[^1]`) across different essays and overwrite earlier definitions. This resulted in all essays sharing the same footnote content, typically from the last processed essays. By prefixing IDs with the essay number (e.g., `[^008-1]`), each footnote becomes globally unique, ensuring correct content in the final EPUB.

---
<p><a href="https://cursor.com/agents/bc-b302b634-1688-4251-8336-c2727712633c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b302b634-1688-4251-8336-c2727712633c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

